### PR TITLE
fix(security): waive base-image twisted CVE-2026-42304

### DIFF
--- a/.github/security/.grype.yaml
+++ b/.github/security/.grype.yaml
@@ -38,6 +38,16 @@ ignore:
       name: libngtcp2-crypto-gnutls8
       type: deb
     reason: "Debian 13 libngtcp2 shipped by tethys-core base image; waiting on base image rebuild to pick up 1.11.0-1+deb13u1."
+  - vulnerability: GHSA-grgv-6hw6-v9g4
+    package:
+      name: twisted
+      type: python
+    reason: "Twisted 25.5.0 ships in the tethys-core conda env; CVE-2026-42304 is a DoS in twisted.names (DNS server), which this app does not run. Upstream fix is 26.4.0rc2 (pre-release); revisit when tethys-core ships a stable bump."
+  - vulnerability: CVE-2026-42304
+    package:
+      name: twisted
+      type: python
+    reason: "Twisted 25.5.0 ships in the tethys-core conda env; CVE-2026-42304 is a DoS in twisted.names (DNS server), which this app does not run. Upstream fix is 26.4.0rc2 (pre-release); revisit when tethys-core ships a stable bump."
 
   # npm is only used at build time (`npm install && npm run build`), and the
   # app's node_modules is removed right after the build. npm's *own* bundled


### PR DESCRIPTION
## Summary
- Adds a Grype waiver for `GHSA-grgv-6hw6-v9g4` / `CVE-2026-42304` (twisted 25.5.0, DoS in `twisted.names`) so the dev-image scan job stops blocking pushes.
- The vulnerable package ships in the `tethysplatform/tethys-core:dev-py3.12-dj5.2` conda env; we don't control the bump, and we don't run `twisted.names` (DNS server) anywhere in the app.
- Upstream fix is `26.4.0rc2` (pre-release). When tethys-core rebuilds with stable twisted ≥ 26.4.0, this waiver should be removed alongside the existing Django / libngtcp2 entries.

Two entries (GHSA + CVE) are listed so Grype matches whichever ID its data source surfaces, mirroring the existing waiver style.

## Test plan
- [ ] `build_push_dev_image` workflow's `scan` job passes on this PR.
- [ ] `Inspect action SARIF report` step shows the twisted finding suppressed.
- [ ] `merge` job runs (i.e. scan no longer fails the pipeline).
