### PR TITLE
fix(viewOnTethys): warn on arch mismatch, pin --platform on pull/run

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,13 @@ podman run --rm -d \
 
 > **WSL note:** Windows browsers reach rootless Podman containers via the WSL VM's IP (e.g. `172.x.x.x`), not via `localhost`. Find it with `ip -4 addr show eth0` and use that address in `ALLOWED_HOSTS`/`CSRF_TRUSTED_ORIGINS` above.
 
+> **Apple Silicon (M1/M2/M3) note:** the published image is multi-arch (`linux/amd64` + `linux/arm64`), but Podman pulls whichever variant matches the `podman machine` VM. If the VM is amd64, daphne runs under QEMU and crash-loops on a SIGSEGV inside Python (symptoms: container goes `unhealthy`, nginx returns `502`). Rebuild the VM as arm64:
+> ```bash
+> podman machine stop && podman machine rm && podman machine init && podman machine start
+> podman rmi docker.io/awiciroh/tethys-ngiab:latest 2>/dev/null
+> ./viewOnTethys.sh -p
+> ```
+
 The `viewOnTethys.sh` launcher in [`NGIAB-CloudInfra`](https://github.com/CIROH-UA/NGIAB-CloudInfra) handles all of this automatically when invoked with `-p`.
 
 ###  Visualization Features 

--- a/viewOnTethys.sh
+++ b/viewOnTethys.sh
@@ -158,9 +158,35 @@ trap 'handle_error "Unexpected error occurred at line $LINENO: $BASH_COMMAND"' E
 # Detect platform
 if uname -a | grep -q 'arm64\|aarch64'; then
     PLATFORM="linux/arm64"
+    HOST_ARCH="arm64"
 else
     PLATFORM="linux/amd64"
+    HOST_ARCH="amd64"
 fi
+
+# Warn when the locally cached image's architecture differs from the host's.
+# On Apple Silicon, a stale amd64 podman-machine VM (or a previously pulled
+# amd64 image) causes daphne to crash under QEMU emulation -- container goes
+# unhealthy, nginx returns 502. Detect that here so the user doesn't sit
+# through the 8-minute healthcheck timeout to discover it.
+warn_if_arch_mismatch() {
+    local image_ref="${TETHYS_REPO}:${TETHYS_TAG}"
+    local image_arch
+    image_arch=$(${DOCKER_CMD} image inspect "$image_ref" \
+                   --format '{{.Architecture}}' 2>/dev/null)
+    [ -z "$image_arch" ] && return 0
+    [ "$image_arch" = "$HOST_ARCH" ] && return 0
+    echo -e "  ${WARNING_MARK} ${BG_Red}${BWhite} Architecture mismatch: image is ${image_arch}, host is ${HOST_ARCH}. ${Color_Off}"
+    echo -e "  ${INFO_MARK} ${BYellow}Tethys will run under emulation and is very likely to crash-loop (daphne SIGSEGV under QEMU).${Color_Off}"
+    if [ "${DOCKER_CMD}" = "podman" ] && [ "$HOST_ARCH" = "arm64" ]; then
+        echo -e "  ${ARROW} ${BWhite}On Apple Silicon, rebuild the podman machine as arm64:${Color_Off}"
+        echo -e "      podman machine stop && podman machine rm && podman machine init && podman machine start"
+        echo -e "      ${DOCKER_CMD} rmi ${image_ref} 2>/dev/null; ${DOCKER_CMD} pull --platform ${PLATFORM} ${image_ref}"
+    else
+        echo -e "  ${ARROW} ${BWhite}Re-pull the matching arch:${Color_Off}"
+        echo -e "      ${DOCKER_CMD} rmi ${image_ref} 2>/dev/null; ${DOCKER_CMD} pull --platform ${PLATFORM} ${image_ref}"
+    fi
+}
 
 # Main functions
 load_teehr_warehouse_path() {
@@ -471,6 +497,7 @@ run_tethys() {
     # port is what the user picked. NGINX_PORT inside matches CONTAINER_PORT.
     echo -e "  ${INFO_MARK} Running ${DOCKER_CMD} command..."
     ${DOCKER_CMD} run --rm -d \
+        --platform "$PLATFORM" \
         "${USERNS_ARGS[@]}" \
         -v "$MODELS_RUNS_DIRECTORY:$TETHYS_PERSIST_PATH/ngiab_visualizer${VOLUME_SUFFIX}" \
         -v "$DATASTREAM_DIRECTORY:$TETHYS_PERSIST_PATH/.datastream_ngiab${VOLUME_SUFFIX}" \
@@ -518,11 +545,13 @@ select_tethys_image_source() {
             read -r decision < /dev/tty
             case "$decision" in
                 [Ll]* )
-                    echo -e "  ${CHECK_MARK} Using local image" ; return 0 ;;
+                    echo -e "  ${CHECK_MARK} Using local image"
+                    warn_if_arch_mismatch
+                    return 0 ;;
                 [Pp]* )
                     echo -e "  ${INFO_MARK} ${BYellow}Pulling image - this may take a moment...${Color_Off}"
                     show_loading "Downloading Tethys image" 3
-                    ${DOCKER_CMD} pull "$image_ref" && return 0
+                    ${DOCKER_CMD} pull --platform "$PLATFORM" "$image_ref" && { warn_if_arch_mismatch; return 0; }
                     echo -e "  ${CROSS_MARK} ${BRed}Failed to pull $image_ref${Color_Off}"
                     return 1 ;;
                 * )


### PR DESCRIPTION
## Summary
Apple Silicon Macs running an amd64 `podman machine` VM pull the amd64 variant of the visualizer image; daphne then crash-loops under QEMU (`SIGSEGV`) and nginx returns `502`. Two small guards in `viewOnTethys.sh` catch this:

- Pass `--platform $PLATFORM` to `pull` and `run` so the matching arch is selected when the engine's default differs.
- `warn_if_arch_mismatch()` compares the local image's `Architecture` to the host's `uname` and prints the exact recovery command (rebuild podman machine + re-pull) before the user spends 8 min watching the healthcheck flip to unhealthy.

README gains a short Apple Silicon note next to the existing WSL note.

## Tested
- WSL2 Ubuntu / Arch (x86_64): `./viewOnTethys.sh` (Docker) and `./viewOnTethys.sh -p` (rootless Podman 5.8) — no spurious warning, container reaches healthy, app reachable on host IP and 127.0.0.1.
- Same host, simulated arch mismatch by hand-overriding `HOST_ARCH=arm64` against the locally-cached amd64 image — warning fires with the recovery snippet.

## Commands
```bash
./viewOnTethys.sh -p
./viewOnTethys.sh -p -t latest
podman image inspect awiciroh/tethys-ngiab:latest --format '{{.Architecture}}'
```